### PR TITLE
[NavBar/Header] NavBar 아이콘 색상 버그 고침

### DIFF
--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -51,8 +51,10 @@ export default function Header({
   onChange,
   buttonId,
   buttonText,
-  followText,
+  headerText,
   disabled,
+  backBtnShow = true,
+  ellipsisBtnShow = false,
 }) {
   const navigate = useNavigate();
   let headerContent;
@@ -75,12 +77,19 @@ export default function Header({
     case 'basic':
       headerContent = (
         <>
-          <IconButton>
-            <BackButton onClick={goBack} />
-          </IconButton>
-          <IconButton>
-            <MoreButton onClick={onClick} />
-          </IconButton>
+          <div>
+            {backBtnShow && (
+              <IconButton>
+                <BackButton onClick={goBack} />
+              </IconButton>
+            )}
+            {headerText && <h1>{headerText}</h1>}
+          </div>
+          {ellipsisBtnShow && (
+            <IconButton>
+              <MoreButton onClick={onClick} />
+            </IconButton>
+          )}
         </>
       );
       break;
@@ -121,31 +130,6 @@ export default function Header({
           >
             {buttonText}
           </Button>
-        </>
-      );
-      break;
-    case 'follow':
-      headerContent = (
-        <>
-          <div>
-            <IconButton>
-              <BackButton onClick={goBack} />
-            </IconButton>
-            <h1>{followText}</h1>
-          </div>
-        </>
-      );
-      break;
-    case 'chat':
-      headerContent = (
-        <>
-          <IconButton>
-            <BackButton onClick={goBack} />
-          </IconButton>
-          <h2>애월읍 위니브 감귤 농장</h2>
-          <IconButton>
-            <MoreButton onClick={onClick} />
-          </IconButton>
         </>
       );
       break;

--- a/src/components/Input/SearchInput.jsx
+++ b/src/components/Input/SearchInput.jsx
@@ -17,7 +17,11 @@ const SearchInputBox = styled.form`
 
 export default function SearchInput({ onChange }) {
   return (
-    <SearchInputBox>
+    <SearchInputBox
+      onSubmit={(e) => {
+        e.preventDefault();
+      }}
+    >
       <label htmlFor="search" className="a11y-hidden">
         계정 검색
       </label>

--- a/src/components/NavBar/NavBar.jsx
+++ b/src/components/NavBar/NavBar.jsx
@@ -1,11 +1,12 @@
 import React from 'react';
 import styled from 'styled-components';
 import NavBarItem from './NavBarItem';
-import { ReactComponent as HomeLink } from '../../assets/icons/icon-home.svg';
-import { ReactComponent as ChatLink } from '../../assets/icons/icon-message.svg';
-import { ReactComponent as PostLink } from '../../assets/icons/icon-edit.svg';
-import { ReactComponent as ProfileLink } from '../../assets/icons/icon-user.svg';
-import { useLocation } from 'react-router-dom';
+import { ReactComponent as HomeIcon } from '../../assets/icons/icon-home.svg';
+import { ReactComponent as ChatIcon } from '../../assets/icons/icon-message.svg';
+import { ReactComponent as PostIcon } from '../../assets/icons/icon-edit.svg';
+import { ReactComponent as ProfileIcon } from '../../assets/icons/icon-user.svg';
+import { useRecoilState } from 'recoil';
+import { pathState } from '../../states/PathState';
 
 const StyledNav = styled.nav`
   position: fixed;
@@ -22,7 +23,7 @@ const StyledNav = styled.nav`
   }
 `;
 
-const StyledHomeLink = styled(HomeLink)`
+const StyledHomeLink = styled(HomeIcon)`
   stroke: ${({ pathname }) =>
     pathname === '/' ? 'var(--main-color)' : 'var(--sub-text-color)'};
   fill: ${({ pathname }) =>
@@ -33,14 +34,14 @@ const StyledHomeLink = styled(HomeLink)`
   }
 `;
 
-const StyledChatLink = styled(ChatLink)`
+const StyledChatLink = styled(ChatIcon)`
   stroke: ${({ pathname }) =>
     pathname === '/chat/' ? 'var(--main-color)' : 'var(--sub-text-color)'};
   fill: ${({ pathname }) =>
     pathname === '/chat/' ? 'var(--main-color)' : 'transparent'};
 `;
 
-const StyledProfileLink = styled(ProfileLink)`
+const StyledProfileLink = styled(ProfileIcon)`
   stroke: ${({ pathname }) =>
     pathname === '/profile/' ? 'var(--main-color)' : 'var(--sub-text-color)'};
   fill: ${({ pathname }) =>
@@ -48,28 +49,36 @@ const StyledProfileLink = styled(ProfileLink)`
 `;
 
 export default function NavBar() {
-  const pathname = useLocation().pathname;
+  const [pathname, setPathname] = useRecoilState(pathState);
+
+  const handleClick = (e) => {
+    setPathname(e.currentTarget.pathname);
+  };
 
   return (
     <StyledNav>
       <ul>
         <li>
-          <NavBarItem to="/" description="홈">
+          <NavBarItem to="/" description="홈" onClick={handleClick}>
             <StyledHomeLink pathname={pathname} />
           </NavBarItem>
         </li>
         <li>
-          <NavBarItem to="/chat/" description="채팅">
+          <NavBarItem to="/chat/" description="채팅" onClick={handleClick}>
             <StyledChatLink pathname={pathname} />
           </NavBarItem>
         </li>
         <li>
-          <NavBarItem to="/post/upload" description="게시물 작성">
-            <PostLink pathname={pathname} />
+          <NavBarItem
+            to="/post/upload"
+            description="게시물 작성"
+            onClick={handleClick}
+          >
+            <PostIcon pathname={pathname} />
           </NavBarItem>
         </li>
         <li>
-          <NavBarItem to="/profile/" description="프로필">
+          <NavBarItem to="/profile/" description="프로필" onClick={handleClick}>
             <StyledProfileLink pathname={pathname} />
           </NavBarItem>
         </li>

--- a/src/components/NavBar/NavBarItem.jsx
+++ b/src/components/NavBar/NavBarItem.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
 import { Link } from 'react-router-dom';
-import IconButton from '../Button/IconButton';
 
 const StyledLink = styled(Link)`
   display: flex;
@@ -19,10 +18,10 @@ const NavDescription = styled.span`
   font-size: 10px;
 `;
 
-export default function NavBarItem({ to, children, description }) {
+export default function NavBarItem({ to, onClick, children, description }) {
   return (
-    <StyledLink to={to}>
-      <IconButton>{children}</IconButton>
+    <StyledLink to={to} onClick={onClick}>
+      {children}
       <NavDescription>{description}</NavDescription>
     </StyledLink>
   );

--- a/src/pages/ChatListPage.jsx
+++ b/src/pages/ChatListPage.jsx
@@ -5,7 +5,7 @@ import ChatList from '../components/Chat/ChatList';
 export default function ChatListPage() {
   return (
     <>
-      <Header type="basic" />
+      <Header type="basic" backBtnShow={false} />
       <ChatList />
     </>
   );

--- a/src/pages/ChatRoomPage.jsx
+++ b/src/pages/ChatRoomPage.jsx
@@ -6,7 +6,7 @@ import TextInputBox from '../components/Input/TextInputBox';
 export default function ChatRoomPage() {
   return (
     <>
-      <Header type="chat" />
+      <Header type="basic" />
       <h2 className="a11y-hidden">대화창</h2>
       <ChatRoom />
       <TextInputBox type="chat" />

--- a/src/pages/FollowersPage.jsx
+++ b/src/pages/FollowersPage.jsx
@@ -40,7 +40,7 @@ export default function FollowersPage() {
   }, []);
   return (
     <>
-      <Header type="follow" followText="Followers" />
+      <Header type="basic" headerText="Followers" backBtnShow={true} />{' '}
       <Main>
         <section>
           <h2 className="a11y-hidden">나를 팔로우하는 사람 리스트</h2>

--- a/src/pages/FollowingsPage.jsx
+++ b/src/pages/FollowingsPage.jsx
@@ -41,7 +41,7 @@ export default function FollowingsPage() {
 
   return (
     <>
-      <Header type="follow" followText="Followings" />
+      <Header type="basic" headerText="Followings" backBtnShow={true} />
       <Main>
         <section>
           <h2 className="a11y-hidden">내가 팔로우 하는 사람 리스트</h2>

--- a/src/pages/MyProfilePage.jsx
+++ b/src/pages/MyProfilePage.jsx
@@ -63,7 +63,12 @@ export default function MyProfilePage() {
 
   return (
     <>
-      <Header type="basic" onClick={onClick} />
+      <Header
+        type="basic"
+        onClick={onClick}
+        backBtnShow={false}
+        ellipsisBtnShow={true}
+      />
       <Container>
         <h1 className="a11y-hidden">나의 프로필 페이지</h1>
         {userData && (

--- a/src/pages/PostPage.jsx
+++ b/src/pages/PostPage.jsx
@@ -111,7 +111,7 @@ export default function PostPage() {
 
   return (
     <>
-      <Header type="basic" />
+      <Header type="basic" backBtnShow={true} />
       <Main>
         <CardStyle>
           {!isLoading && (

--- a/src/pages/UserProfilePage.jsx
+++ b/src/pages/UserProfilePage.jsx
@@ -1,18 +1,13 @@
 import styled from 'styled-components';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 import { useState } from 'react';
 import { useEffect } from 'react';
-import { useSetRecoilState } from 'recoil';
-import { loginState } from '../states/LoginState';
 import authInstance from '../api/instance/authInstance';
 import Header from '../components/Header/Header';
 import ProfileInfo from '../components/Profile/ProfileInfo';
 import ProfileProducts from '../components/Profile/ProfileProducts';
 import ProfilePosts from '../components/Profile/ProfilePosts';
 import NavBar from '../components/NavBar/NavBar';
-import BottomSheetModal from '../components/Modal/BottomSheetModal';
-import BottomSheetContent from '../components/Modal/BottomSheetContent';
-import ConfirmModal from '../components/Modal/ConfirmModal';
 
 const Container = styled.main`
   display: flex;
@@ -27,11 +22,6 @@ const Container = styled.main`
 export default function UserProfilePage() {
   const { _id } = useParams();
   const [userData, setUserData] = useState('');
-  const [isMenuOpen, setIsMenuOpen] = useState(false);
-  const [isModalOpen, setIsModalOpen] = useState(false);
-
-  const navigate = useNavigate();
-  const setIsLogined = useSetRecoilState(loginState);
 
   useEffect(() => {
     const fetchUserData = async () => {
@@ -47,25 +37,9 @@ export default function UserProfilePage() {
     fetchUserData();
   }, [userData.isfollow]);
 
-  const onClick = () => {
-    setIsMenuOpen(!isMenuOpen);
-  };
-
-  const openModal = () => {
-    setIsMenuOpen(true);
-    setIsModalOpen(true);
-  };
-
-  const handleLogout = () => {
-    localStorage.removeItem('token');
-    localStorage.removeItem('accountname');
-    localStorage.removeItem('image');
-    setIsLogined(false);
-  };
-
   return (
     <>
-      <Header type="basic" onClick={onClick} />
+      <Header type="basic" />
       <Container>
         <h1 className="a11y-hidden">나의 프로필 페이지</h1>
         {userData && (
@@ -76,29 +50,6 @@ export default function UserProfilePage() {
           </>
         )}
         <NavBar />
-        {isMenuOpen && (
-          <BottomSheetModal setIsMenuOpen={setIsMenuOpen}>
-            <BottomSheetContent
-              onClick={() => {
-                navigate('/profile/edit');
-              }}
-            >
-              설정 및 개인정보
-            </BottomSheetContent>
-            <BottomSheetContent onClick={openModal}>
-              로그아웃
-            </BottomSheetContent>
-          </BottomSheetModal>
-        )}
-        {isModalOpen && (
-          <ConfirmModal
-            title="로그아웃하시겠어요?"
-            confirmInfo="로그아웃"
-            setIsMenuOpen={setIsMenuOpen}
-            setIsModalOpen={setIsModalOpen}
-            onClick={handleLogout}
-          />
-        )}
       </Container>
     </>
   );

--- a/src/pages/WelcomePage.jsx
+++ b/src/pages/WelcomePage.jsx
@@ -8,7 +8,7 @@ import kakao from '../assets/icons/kakao.svg';
 import google from '../assets/icons/google.svg';
 import facebook from '../assets/icons/facebook.svg';
 
-const Header = styled.header`
+const StyledHeader = styled.header`
   margin-top: 139px;
 
   & > h1 {
@@ -79,12 +79,12 @@ const SnsBtnContainer = styled.div`
 export default function WelcomePage() {
   return (
     <div>
-      <Header>
+      <StyledHeader>
         <h1>
           <span className="a11y-hidden">Focal 로고 버튼</span>
           <img src={Logo} alt="Focal 로고 이미지" />
         </h1>
-      </Header>
+      </StyledHeader>
       <Main>
         <section>
           <h2 className="a11y-hidden">로그인, 회원가입</h2>

--- a/src/states/PathState.js
+++ b/src/states/PathState.js
@@ -1,0 +1,21 @@
+import { atom } from 'recoil';
+
+const localStorageEffect = ({ setSelf, onSet }) => {
+  const savedValue = localStorage.getItem('pathname');
+  console.log(savedValue, window.location.pathname);
+  if (savedValue != null) {
+    if (window.location.pathname === savedValue) {
+      setSelf(savedValue);
+    }
+  }
+
+  onSet((newValue) => {
+    localStorage.setItem('pathname', newValue);
+  });
+};
+
+export const pathState = atom({
+  key: 'pathState',
+  default: '/',
+  effects: [localStorageEffect],
+});


### PR DESCRIPTION
### ✅ PR 요청 전 체크 사항
- [x] 제목 형식은 다음과 같습니다: `[작업 파트] 작업 내용`
- [x] `Reviewers`, `Assignees`, `Labels` 모두 지정해주세요.
- [x] 불필요한 코드나 주석은 모두 지워주세요.


## ✨ 무엇을 위한 PR인가요?
NavBar 아이콘 색상 버그 고침


## ⌨️ 작업 내용을 상세히 적어주세요
- 기존 코드에서는 window.location.path에 따라 네비게이션 아이콘의 색상이 변하게 코드를 작성하여 '/' path에서 '/search' path로 경로가 변경되면 홈아이콘에 색상이 들어와있어야 함에도 불구하고 들어와 있지 않은 버그를 발견
- 따라서 전역상태(Recoil)로 pathState를 선언하고 NavBar의 아이콘을 눌렀을 때만 pathState를 set할 수 있도록 구현함.
- Header의 경우 type chat과 follow를 없애고 headerText, backBtnShow, ellipsisBtnShow props를 추가하여 조금 더 코드를 재활용할 수 있도록 구성함
- UserProfilePage에서 Header에 ellipsisBtn을 보이지 않게 디자인을 변경하여 ellipsisBtn을 눌렀을 때 기존에 로그아웃 처리를 하기 위한 비즈니스 로직을 삭제함




## 🖇️ 참고 사항
- 기존 NavBar 오류
![ezgif-3-d5aaf9cd93](https://github.com/FRONTENDSCHOOL5/final-01-focal/assets/75666099/fa595ac0-eee4-4665-968e-4fc81da8612f)

- NavBar 오류 고침
![ezgif-3-63226e47d4](https://github.com/FRONTENDSCHOOL5/final-01-focal/assets/75666099/36119110-e693-471e-b8c5-8c8302da9615)

