### PR TITLE
[Feed] PostsFeed data fetch 버그 해결 및 디자인 문제 해결 

### DIFF
--- a/src/components/Post/PostsFeed.jsx
+++ b/src/components/Post/PostsFeed.jsx
@@ -24,6 +24,7 @@ export default function PostsFeed({
 }) {
   const [isLoadingMore, setIsLoadingMore] = useState(false);
   const [page, setPage] = useState(1);
+  const [isLastPage, setIsLastPage] = useState(false);
   const contentRef = useRef(null);
   const LIMIT = 10;
 
@@ -41,14 +42,23 @@ export default function PostsFeed({
     setIsLoadingMore(true);
     const newPosts = await feedAPI(LIMIT, page * LIMIT);
     setIsLoadingMore(false);
-    if (newPosts.length > 0) {
-      setPostDatas((prevPosts) => [...prevPosts, ...newPosts]);
+    setPostDatas((prevPosts) => [...prevPosts, ...newPosts]);
+
+    if (newPosts.length < LIMIT) {
+      setIsLastPage(true);
+      return;
+    }
+    if (newPosts.length === LIMIT) {
       setPage((prevPage) => prevPage + 1);
     }
   };
 
   const handleIntersection = (entries) => {
-    if (entries[0].isIntersecting && entries[0].intersectionRatio > 0) {
+    if (
+      entries[0].isIntersecting &&
+      entries[0].intersectionRatio > 0 &&
+      !isLastPage
+    ) {
       getMorePosts();
     }
   };

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -23,7 +23,7 @@ const Container = styled.section`
   display: flex;
   min-height: 100%;
   flex-direction: column;
-  justify-content: center;
+  justify-content: ${({ data }) => (data.length ? 'flex-start' : 'center')};
   align-items: center;
   padding: 16px;
   gap: 20px;
@@ -74,7 +74,7 @@ export default function HomePage() {
       <Header type="main" onClick={scrollToTop} />
       <ContentWrapper ref={scrollRef}>
         <h2 className="a11y-hidden">Focal 홈 피드</h2>
-        <Container>
+        <Container data={postDatas}>
           <h3 className="a11y-hidden">내가 팔로우한 사람 글 목록</h3>
           <PostsFeed
             setIsLoading={setIsLoading}


### PR DESCRIPTION
### ✅ PR 요청 전 체크 사항
- [x] 제목 형식은 다음과 같습니다: `[작업 파트] 작업 내용`
- [x] `Reviewers`, `Assignees`, `Labels` 모두 지정해주세요.
- [x] 불필요한 코드나 주석은 모두 지워주세요.


## ✨ 무엇을 위한 PR인가요?
-  postsFeed data fetch 버그 해결
- Feed 디자인 문제 해결

## ⌨️ 작업 내용을 상세히 적어주세요
### 1. PostsFeed 컴포넌트 data fetch 버그 해결
- PostsFeed 컴포넌트에서 더이상 불러올 피드데이터가 없음에도 불구하고 무한으로 데이터를 불러오는 것을 확인함, 무한 스크롤을 구현하는 과정에서 문제가 일어난 것으로 보임. <img width="959" alt="image" src="https://github.com/FRONTENDSCHOOL5/final-01-focal/assets/75666099/25c02f67-7d24-4b7a-a9f4-52838f8f1261">
- 이를 해결하기 위해 더이상 가져올 피드데이터가 없을 때를 나타내는 isLastPage 상태를 새로 만들어서 isLastPage가 true이면 더이상 데이터를 가져오지 않도록 구현함.

### 2. 디자인 문제 해결 
- 데이터가 한 개 일 때 가운데로 배치되는 것이 부자연스럽게 느껴짐. 따라서 styled-component에서 props로 data의 length가 0이 아닐때와 0일때를 구별하여 data의 length가 0이 아니면 justfy-content를 'flex-start'로 0이면 'center'로 스타일링 해줌 
  ```
  justify-content: ${({ data }) => (data.length ? 'flex-start' : 'center')};
  ```
- 데이터가 한 개일 때 가운데로 배치된 상태
![image](https://github.com/FRONTENDSCHOOL5/final-01-focal/assets/75666099/5b9e418c-10b8-4ad3-a939-1bca1a875062)


## 🖇️ 참고 사항
